### PR TITLE
Add TikZ picture in file

### DIFF
--- a/tex/biblio.bib
+++ b/tex/biblio.bib
@@ -1,9 +1,16 @@
-@article{Python, 
+@article{Python,
 title= {Python tutorial},
 author = {G. van Rossum},
 number={CS-R9526},
 institution= {Centrum voor Wiskunde en Informatica (CWI)},
 year= {1995},
-address={Amsterdam}, 
+address={Amsterdam},
 month={May}
+}
+@online{Flandrin18theconversation,
+Author = {Flandrin, Patrick},
+Title = {Signal processing: a field at the heart of science and everyday life},
+Url = {https://theconversation.com/signal-processing-a-field-at-the-heart-of-science-and-everyday-life-89267},
+Urldate = {2018-06-07},
+Year = 2018,
 }

--- a/tex/images/goldentriangle.tex
+++ b/tex/images/goldentriangle.tex
@@ -1,0 +1,15 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\begin{document}
+\begin{tikzpicture}
+  \node (A) at (2, 0) [right, text width=3cm, align=center]{computer science};
+  \node (B) at (-2, 0) [left, text width=3cm, align=center]{mathematics};
+  \node (C) at (0, 2.828) [above, ] {physics};
+
+
+  \filldraw[blue!10, ultra thick] (2, 0) -- (-2, 0) -- (0, 2.828) -- (2, 0);
+  \draw[yellow!40, ultra thick] (2, 0) -- (-2, 0) -- (0, 2.828) -- (2, 0);
+  \node at (0, 1.1) [text width=5em, align=center]{signal processing};
+\end{tikzpicture}
+\end{document}

--- a/tex/paper.tex
+++ b/tex/paper.tex
@@ -44,7 +44,7 @@ The project is available on \href{https://github.com/CRIStAL-Sigma/reproducible-
 
 	\subsection{Basic} % (fold)
 	\label{sub:basic}
-		
+
 		\begin{figure}[h]
 			\label{fig:collabocats}
 			\centering
@@ -56,7 +56,13 @@ The project is available on \href{https://github.com/CRIStAL-Sigma/reproducible-
 
 	\subsection{with TikZ} % (fold)
 	\label{sub:with_tikz}
-		
+
+	\begin{figure}[h]
+		\centering
+		\includegraphics{images/goldentriangle}
+		\caption{The ``golden triangle'' of signal processing. Adapted from \cite{Flandrin18theconversation}}
+	\end{figure}
+
 	% subsection with_tikz (end)
 
 % section images (end)


### PR DESCRIPTION
@guilgautier, this should address your request. 
One issue though: I have externalized the tikz figure into a standalone tex document, and since pdf files are excluded in the repo (see .gitignore) one needs to compile images/goldentriangle.tex before the main document.

I could put the tikz code directly into the main document if you prefer. 